### PR TITLE
delall 機能を追加しました。

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "twi-st_hook"
-version = "2.1.0"
+name = "twisthook"
+version = "2.2.0"
 authors = ["MogyuMogu <69337624+MogyuMogu@users.noreply.github.com>"]
 edition = "2018"
 
@@ -11,5 +11,6 @@ chrono = "0.4.19"
 dotenv = "0.15.0"
 futures-util = "0.3.13"
 json_flex = "0.3.3"
+regex = "1.4.3"
 reqwest = { version = "0.11.1", features = ["stream"] }
 tokio = { version = "1.2.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # TwiStHook
+
+[![GitHub license](https://img.shields.io/github/license/mii-community/TwiStHook)](https://github.com/mii-community/TwiStHook/blob/main/LICENSE)
+
 from Twitter API v2 Filtered Stream to WebHook

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn post_rules(map: HeaderMap) {
     println!("{}", response);
 }
 
-async fn get_rules(map:HeaderMap) {
+async fn get_rules(map: HeaderMap) {
     let endpoint = "https://api.twitter.com/2/tweets/search/stream/rules";
     let response = reqwest::Client::new()
         .request(reqwest::Method::GET, endpoint)
@@ -46,7 +46,7 @@ async fn get_rules(map:HeaderMap) {
     println!("{}", response);
 }
 
-async fn del_rules(map:HeaderMap) {
+async fn del_rules(map: HeaderMap) {
     let client = reqwest::Client::new();
     let endpoint = "https://api.twitter.com/2/tweets/search/stream/rules";
     let response = client.post(endpoint)
@@ -62,7 +62,7 @@ async fn del_rules(map:HeaderMap) {
     println!("{}", response);
 }
 
-async fn filtered_stream(map:HeaderMap) {
+async fn filtered_stream(map: HeaderMap) {
     let endpoint = "https://api.twitter.com/2/tweets/search/stream";
     let mut stream = reqwest::Client::new()
         .request(reqwest::Method::GET, endpoint)


### PR DESCRIPTION
`delall`を引数に指定して実行すると、現在指定されている stream rules を全て削除できます。

close #4 